### PR TITLE
## 1.1.25-beta (October 26, 2023)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.1.25-beta (October 26, 2023)
+BUGFIXES:
+* Hardcoded sleep in dnacenter_floor, dnacenter_area resources #227 - 1 minute sleep removed.
+
 ## 1.1.24-beta (October 25, 2023)
 BUGFIXES:
 * Resource dnacenter_wireless_profile does not support adding new SSIDs to profile #229.

--- a/dnacenter/resource_area.go
+++ b/dnacenter/resource_area.go
@@ -405,7 +405,7 @@ func resourceAreaDelete(ctx context.Context, d *schema.ResourceData, m interface
 	resourceID := d.Id()
 	resourceMap := separateResourceID(resourceID)
 	vSiteID := resourceMap["site_id"]
-	time.Sleep(1 * time.Minute)
+	// time.Sleep(1 * time.Minute)
 	// queryParams1 := dnacentersdkgo.GetSiteQueryParams{}
 	// queryParams1.Name = vName
 	// queryParams1.SiteID = vSiteID

--- a/dnacenter/resource_floor.go
+++ b/dnacenter/resource_floor.go
@@ -565,7 +565,7 @@ func resourceFloorDelete(ctx context.Context, d *schema.ResourceData, m interfac
 	resourceID := d.Id()
 	resourceMap := separateResourceID(resourceID)
 	vSiteID := resourceMap["site_id"]
-	time.Sleep(1 * time.Minute)
+	// time.Sleep(1 * time.Minute)
 	// queryParams1 := dnacentersdkgo.GetSiteQueryParams{}
 	// queryParams1.Name = vName
 	// queryParams1.SiteID = vSiteID


### PR DESCRIPTION
BUGFIXES:
* Hardcoded sleep in dnacenter_floor, dnacenter_area resources #227 - 1 minute sleep removed.