### PR TITLE
Fixed the HTTP credentials issue

### DIFF
--- a/dnacenter/data_source_device_credential.go
+++ b/dnacenter/data_source_device_credential.go
@@ -531,7 +531,7 @@ func flattenNetworkSettingsGetDeviceCredentialDetailsItemHTTPRead(items *[]dnace
 	var respItems []map[string]interface{}
 	for _, item := range *items {
 		respItem := make(map[string]interface{})
-		respItem["secure"] = item.Secure
+		respItem["secure"] = string(item.Secure)
 		respItem["username"] = item.Username
 		respItem["password"] = item.Password
 		respItem["port"] = item.Port
@@ -553,7 +553,7 @@ func flattenNetworkSettingsGetDeviceCredentialDetailsItemHTTPWrite(items *[]dnac
 	var respItems []map[string]interface{}
 	for _, item := range *items {
 		respItem := make(map[string]interface{})
-		respItem["secure"] = item.Secure
+		respItem["secure"] = string(item.Secure)
 		respItem["username"] = item.Username
 		respItem["password"] = item.Password
 		respItem["port"] = item.Port

--- a/dnacenter/data_source_global_credential.go
+++ b/dnacenter/data_source_global_credential.go
@@ -348,7 +348,7 @@ func flattenDiscoveryGetGlobalCredentialsItems(items *[]dnacentersdkgo.ResponseD
 		respItem["privacy_password"] = item.PrivacyPassword
 		respItem["privacy_type"] = item.PrivacyType
 		respItem["snmp_mode"] = item.SNMPMode
-		respItem["secure"] = item.Secure
+		respItem["secure"] = string(item.Secure)
 		respItem["port"] = item.Port
 		respItem["comments"] = item.Comments
 		respItem["credential_type"] = item.CredentialType


### PR DESCRIPTION
#### Summary ####
Fixed the HTTP credentials issue in the terraform provider. 

#### Root Cause ####
The problem was a type mismatch where the API returns secure as a boolean but the SDK expected a string.

#### Solution Applied #### 
- Created a custom BoolString type that can unmarshal both boolean and string JSON values
- Updated SDK structs to use BoolString for the secure field
- Modified provider code to convert BoolString to string when processing data